### PR TITLE
Remove Pettan weapons, update Massivesoft guns, add more WTT guns

### DIFF
--- a/MissingQuestWeapons/OverriddenWeapons.jsonc
+++ b/MissingQuestWeapons/OverriddenWeapons.jsonc
@@ -66,6 +66,30 @@
         "weapon_93_raffica": "Pistol,Smg",
         "weapon_striker_12": "Shotgun",
         "weapon_imi_uzi": "Smg",
+        "020020DF056DF05600000000": "AssaultCarbine,AssaultRifle", // DG-56 5.56x45mm
+        "020020F15FF15F0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok 5.56x45mm
+        "020020F15DF15D0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok 7.62x51mm
+        "020020F15EF15E0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok .300 BLK
+        "020020F150F1500000000000": "Smg", // ISO 9x19mm
+        "020020F154F1540000000000": "Smg", // ISO 9x19mm
+        "020020F151F1510000000000": "Smg", // ISO 9x19mm
+        "020020F152F1520000000000": "Smg", // ISO .45 ACP
+        "020020F153F1530000000000": "Smg", // ISO .45 ACP
+        "023023A12A12A12000000000": "Shotgun", // JAK-12 (AA-12) 12ga
+        "02002010AB10AB0000000000": "BoltActionSniperRifle", // Longbow (Bolt-action AK-103) 7.62x39mm
+        "020020AA14AA140000000000": "MarksmanRifle", // M14 7.62x51mm
+        "0210211911CE000000000000": "Pistol", // M1911 CE .45 ACP
+        "020020AACBBB1C0000000000": "AssaultRifle", // MCW (ACR) 5.56x45mm
+        "020020AACBBFDE0000000000": "AssaultRifle", // MCW (ACR) FDE 5.56x45mm
+        "020020AACBB3000000000000": "AssaultRifle", // MCW (ACR) .300 BLK
+        "020020AACBBA1A0000000000": "AssaultRifle", // MCW (ACR) (not sure which caliber)
+        "020020AACBBCFB0000000000": "AssaultRifle", // MCW (ACR) (not sure which caliber)
+        "020020BBA03BBA0300000000": "AssaultCarbine,AssaultRifle", // QBZ-03 5.56x45mm
+        "020020BBA97BBA9700000000": "AssaultCarbine,AssaultRifle", // QBZ-97 5.56x45mm
+        "020020195195F95556000000": "AssaultCarbine,AssaultRifle", // TAR x95 5.56x45mm
+        "020020195195F95545000000": "AssaultCarbine,AssaultRifle", // TAR x95 5.45x39mm
+        "022022C64C64000000000000": "Smg", // Type 64 7.62x25mm
+        "020020308308000000000000": "AssaultRifle", // V308 7.62x51mm
         "d672109946fe88b803449054": "AssaultRifle", // AK-101 .300 BLK
         "939c742f7dad852286188029": "AssaultCarbine,AssaultRifle", // AKS-74UB .300 BLK
         "627c4fe34b0a558e8a3642a1": "AssaultCarbine,AssaultRifle", // AKS-74UN .300 BLK
@@ -79,27 +103,6 @@
         "52ce1b65b13e1035808c4fd2": "AssaultRifle", // Mk47 5.45x39mm
         "96f5c38a676e11e13544dfba": "AssaultRifle", // Mk47 9x39mm
         "8d59d8b10a4c2e85b871c317": "AssaultRifle", // MCX Spear .308
-        "weapon_JAK12_12ga_MASSIVESOFT": "Shotgun", // Pettan JAK12 port
-        "weapon_AA12_12ga_MASSIVESOFT": "Shotgun", // Pettan JAK12 alternative, for those who renamed it.
-        "023023A12A12A12000000000": "Shotgun", // Massivesoft JAK12
-        "weapon_M14_762x51_MASSIVESOFT": "AssaultRifle,MarksmanRifle", // Pettan M14 port
-        "020020AA14AA140000000000": "AssaultRifle,MarksmanRifle", // Massivesoft M14
-        "weapon_M1911CE_1143x23_MASSIVESOFT": "Pistol", // Pettan M1911CE port
-        "0210211911CE000000000000": "Pistol", // Massivesoft M1911CE
-        "weapon_QBZ03_std_MASSIVESOFT": "AssaultRifle,AssaultCarbine", // Pettan QBZ03 port
-        "020020BBA03BBA0300000000": "AssaultRifle,AssaultCarbine", // Massivesoft QBZ03
-        "020020BBA97BBA9700000000": "AssaultRifle,AssaultCarbine", // Massivesoft QBZ97
-        "020020195195F95556000000": "AssaultRifle,AssaultCarbine", // Massivesoft Tavor X95
-        "020020195195F95545000000": "AssaultRifle,AssaultCarbine", // Massivesoft Tavor X95-R
-        "weapon_TYPE64_762x25_MASSIVESOFT": "Smg", // Pettan Type 64 port
-        "022022C64C64000000000000": "Smg", // Massivesoft Type 64
-        "weapon_v308_762x51_MASSIVESOFT": "AssaultRifle", // Pettan v308 port
-        "020020308308000000000000": "AssaultRifle", // Massivesoft v308
-        "MIRA_weapon_ai_awm_338lm": "BoltActionSniperRifle,SniperRifle",
-        "MIRA_weapon_colt_m16a4_556x45": "AssaultRifle",
-        "MIRA_weapon_izhmash_ak_762x39_nodove": "AssaultRifle",
-        "MIRA_weapon_izhmash_ak_762x39": "AssaultRifle",
-        "MIRA_weapon_izhmash_rpk74n_545x39": "AssaultRifle,MachineGun",
         "Asset Store knife": "Knife",
         "66015072e9f84d5680039678": "Pistol", // Plastic toy gun, good luck with that
         "663fe6eb47e8baf835124234": "Pistol", // Desert Eagle .357 Magnum

--- a/MissingQuestWeapons/OverriddenWeapons.jsonc
+++ b/MissingQuestWeapons/OverriddenWeapons.jsonc
@@ -31,17 +31,15 @@
         "5d52cc5ba4b9367408500062": "GrenadeLauncher", // AGS-30 30x29mm automatic grenade launcher
         "6275303a9f372d6ea97f9ec7": "GrenadeLauncher", // Milkor M32A1 MSGL 40mm grenade launcher
         "620109578d82e67e7911abf2": "GrenadeLauncher,Pistol", // ZiD SP-81 26x75 signal pistol
-        "6657bc8faeddd6b0a9b40224": "MarksmanRifle", // SVD 7.62x54R Sniper Rifle
-        "6657bd4d3a4d6e7c33fd2fdc": "MarksmanRifle", // SVD 7.62x54R Sniper Rifle
         "61f7c9e189e6fb1a5e3ea78d": "BoltActionSniperRifle,SniperRifle,Shotgun,PumpActionShotgun", // MP-18 7.62x54R single-shot rifle (god gives his toughest types to his strongest weapons)
         "0101_BLACK_LINES_M4A1": "AssaultCarbine,AssaultRifle",
         "0102_BLACK_LINES_AK103": "AssaultRifle",
         "0103_BLACK_RSASS": "MarksmanRifle",
-        "0104_BLACK_LINES_MK47": "AssaultCarbine,AssaultRifle",
-        "0105_BLACK_AUG": "AssaultCarbine,AssaultRifle",
+        "0104_BLACK_LINES_MK47": "AssaultRifle",
+        "0105_BLACK_AUG": "AssaultRifle",
         "0106_FLAMING_M4A1": "AssaultCarbine,AssaultRifle",
         "0107_PRISTINE_M4A1": "AssaultCarbine,AssaultRifle",
-        "0108_BLACK_SPEAR": "AssaultCarbine,AssaultRifle",
+        "0108_BLACK_SPEAR": "AssaultRifle",
         "gc_1_MDR_556": "AssaultCarbine,AssaultRifle",
         "gc_2_MDR_762": "AssaultCarbine,AssaultRifle",
         "gc_3_M4A1_green": "AssaultCarbine,AssaultRifle",
@@ -53,7 +51,7 @@
         "SC_0106_AK104_SAND": "AssaultCarbine,AssaultRifle",
         "SC_0107_AK105_SAND": "AssaultCarbine,AssaultRifle",
         "SC_0108_HK416_SAND": "AssaultCarbine,AssaultRifle",
-        "SC_0109_G36_SAND": "AssaultCarbine,AssaultRifle",
+        "SC_0109_G36_SAND": "AssaultRifle",
         "SC_01010_M4A1_SAND_2": "AssaultCarbine,AssaultRifle",
         "wc_010421_WHITE_M4A1": "AssaultCarbine,AssaultRifle",
         "weapon_tactikal_gladius": "Knife",
@@ -66,10 +64,11 @@
         "weapon_93_raffica": "Pistol,Smg",
         "weapon_striker_12": "Shotgun",
         "weapon_imi_uzi": "Smg",
-        "020020DF056DF05600000000": "AssaultCarbine,AssaultRifle", // DG-56 5.56x45mm
-        "020020F15FF15F0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok 5.56x45mm
-        "020020F15DF15D0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok 7.62x51mm
-        "020020F15EF15E0000000000": "AssaultCarbine,AssaultRifle", // ISO Hemlok .300 BLK
+        // Massivesoft weapons
+        "020020DF056DF05600000000": "AssaultRifle", // DG-56 5.56x45mm
+        "020020F15FF15F0000000000": "AssaultRifle", // ISO Hemlok 5.56x45mm
+        "020020F15DF15D0000000000": "AssaultRifle", // ISO Hemlok 7.62x51mm
+        "020020F15EF15E0000000000": "AssaultRifle", // ISO Hemlok .300 BLK
         "020020F150F1500000000000": "Smg", // ISO 9x19mm
         "020020F154F1540000000000": "Smg", // ISO 9x19mm
         "020020F151F1510000000000": "Smg", // ISO 9x19mm
@@ -84,12 +83,50 @@
         "020020AACBB3000000000000": "AssaultRifle", // MCW (ACR) .300 BLK
         "020020AACBBA1A0000000000": "AssaultRifle", // MCW (ACR) (not sure which caliber)
         "020020AACBBCFB0000000000": "AssaultRifle", // MCW (ACR) (not sure which caliber)
-        "020020BBA03BBA0300000000": "AssaultCarbine,AssaultRifle", // QBZ-03 5.56x45mm
-        "020020BBA97BBA9700000000": "AssaultCarbine,AssaultRifle", // QBZ-97 5.56x45mm
+        "020020BBA03BBA0300000000": "AssaultRifle", // QBZ-03 5.56x45mm
+        "020020BBA97BBA9700000000": "AssaultRifle", // QBZ-97 5.56x45mm
         "020020195195F95556000000": "AssaultCarbine,AssaultRifle", // TAR x95 5.56x45mm
         "020020195195F95545000000": "AssaultCarbine,AssaultRifle", // TAR x95 5.45x39mm
         "022022C64C64000000000000": "Smg", // Type 64 7.62x25mm
         "020020308308000000000000": "AssaultRifle", // V308 7.62x51mm
+        // WTT weapons
+        "6671ebcdd32bd95eb398e920": "AssaultRifle,AssaultCarbine", // Ak5C 5.56x45mm
+        "668c45bf9069178d4b1f225c": "BoltActionSniperRifle,SniperRifle", // Arisaka Type 99 7.7x58mm
+        "66c01f332770caf084f35480": "SniperRifle", // Barrett M107A1 .50 BMG
+        "66c13c53999e17f0702c2e70": "SniperRifle", // Barrett M107A1 FDE .50 BMG
+        "66945f346fd04c33d4f9bc35": "AssaultRifle,AssaultCarbine", // Beretta ARX160 5.56x45mm
+        "6696b5e6ed3ac659cc619eff": "AssaultRifle,AssaultCarbine", // Beretta ARX160 FDE 5.56x45mm
+        "6696b5f5520265c38b644920": "AssaultRifle,AssaultCarbine", // Beretta ARX160 OD 5.56x45mm
+        "6696b60855a9454cbc033d4e": "AssaultRifle,AssaultCarbine", // Beretta ARX160 WHITE 5.56x45mm
+        "6681810d4f568d3cb0c7187c": "Pistol", // Rexana Blicky
+        "669fca7f9ed4916116c76d5e": "Shotgun", // Browning Auto-5 12ga
+        "667b693466834848ed0c05a6": "BoltActionSniperRifle,SniperRifle", // CheyTac M200 Intervention .408 CheyTac
+        "6661012d16fbd2fb75408f87": "Pistol", // CZ-75 9x19mm
+        "66b7d231babb635f70257534": "Pistol", // Desert Eagle Gold .50 AE
+        "664a5b945636ce820472f225": "AssaultRifle,MarksmanRifle", // HK417 7.62x51mm
+        "66e5b5e16c48ad4b4735cfbc": "AssaultRifle,MarksmanRifle", // Hoshizora SCAR 17 7.62x51mm
+        "66ba249b102a9dd6040a6e7e": "AssaultRifle,AssaultCarbine", // IWI Carmel 5.56x45mm
+        "66ba26a6925f9921573224c9": "AssaultRifle,AssaultCarbine", // IWI Carmel FDE 5.56x45mm
+        "66a2d15b2500a672aa10d9ff": "AssaultRifle", // IWI Tavor TAR-21 5.56x45mm
+        "66a37082da8293dc5e0a377d": "AssaultRifle", // IWI Tavor TAR-21 FDE 5.56x45mm
+        "66a47e98c486ec9d1af3a4da": "AssaultRifle,AssaultCarbine", // IWI Tavor x95 5.56x45mm
+        "66a544c956621d3364f6085e": "AssaultRifle,AssaultCarbine", // IWI Tavor x95 FDE 5.56x45mm
+        "66a545898022784400d6c836": "AssaultRifle,AssaultCarbine", // IWI Tavor x95 OD 5.56x45mm
+        "66e718dc498d978477e0ba75": "MachineGun", // M249 SAW 5.56x45mm
+        "deee28079e76d537f532021c": "BoltActionSniperRifle,SniperRifle", // M700 .338 Lapua Magnum
+        "1bf618e47cce6d69bec01e9f": "BoltActionSniperRifle,SniperRifle", // M700 .338 Norma Mag
+        "66839591f4d0cba7b041b2af": "AssaultRifle,AssaultCarbine", // Patriot 1776 (M4A1) 5.56x45mm
+        "66ca50aacb9b900a4c8a5545": "AssaultRifle", // Remington ACR 5.56x45mm
+        "66cbc1d13919ac843e616d84": "BoltActionSniperRifle,SniperRifle", // Remington MSR 7.62x51mm
+        "66b9de8cf34d11aa91b5f20c": "AssaultRifle", // Remington R5 5.56x45mm
+        "665fe0e865683281eb8e7ed6": "Pistol", // Springfield Prodigy 9x19mm
+        "6657bc8faeddd6b0a9b40224": "MarksmanRifle, SniperRifle", // SVD 7.62x54R Sniper Rifle (wood)
+        "6657bd4d3a4d6e7c33fd2fdc": "MarksmanRifle, SniperRifle", // SVD 7.62x54R Sniper Rifle (camo)
+        "6668df22e6b592f28024be10": "AssaultRifle,AssaultCarbine", // WoS AR-15 5.56x45mm
+        "6668ddd37b793f48deb730d4": "AssaultRifle,AssaultCarbine", // WoS AR-15 Red 5.56x45mm
+        "663cf1da2496a8e7b0b71759": "Pistol", // WC EDC X9 9x19mm
+        "66e88596febdcf9daade16a8": "MarksmanRifle, SniperRifle", // Zastava M76 7.92x57mm
+        //
         "d672109946fe88b803449054": "AssaultRifle", // AK-101 .300 BLK
         "939c742f7dad852286188029": "AssaultCarbine,AssaultRifle", // AKS-74UB .300 BLK
         "627c4fe34b0a558e8a3642a1": "AssaultCarbine,AssaultRifle", // AKS-74UN .300 BLK
@@ -106,12 +143,6 @@
         "Asset Store knife": "Knife",
         "66015072e9f84d5680039678": "Pistol", // Plastic toy gun, good luck with that
         "663fe6eb47e8baf835124234": "Pistol", // Desert Eagle .357 Magnum
-        "6671ebcdd32bd95eb398e920": "AssaultRifle,AssaultCarbine", // Ak5C 5.56x45mm
-        "667b693466834848ed0c05a6": "BoltActionSniperRifle,SniperRifle", // CheyTac M200 Intervention .408 CheyTac
-        "6661012d16fbd2fb75408f87": "Pistol", // CZ-75 9x19mm
-        "664a5b945636ce820472f225": "AssaultRifle,MarksmanRifle", // HK417 7.62x51mm
-        "663cf1da2496a8e7b0b71759": "Pistol", // EDCX9 9x19mm
-        "665fe0e865683281eb8e7ed6": "Pistol", // DS Prodigy 9x19mm
         "664274a4d2e5fe0439d545a6": "AssaultRifle,AssaultCarbine", // HK G3 7.62x51mm
         "664274afd9fe3879695d90e9": "AssaultRifle,MachineGun", // HK G3 11E 7.62x51mm
         "czscorpion": "Smg", // CZ Scorpion EVO 3 9x19mm


### PR DESCRIPTION
It's ya boy

- Removed references to Pettan weapons since they're probably not coming back
- Redid Massivesoft IDs and added some missing ones
- Removed carbine type from non-carbines
- Added more WTT weapons

I'm sure this can be done more efficiently somehow. Could it be worth looking into recommending people load this mod after all weapons, and then searching through the DB for weapons and their type?